### PR TITLE
improve performance of column resizing

### DIFF
--- a/src/table/table-state.ts
+++ b/src/table/table-state.ts
@@ -112,12 +112,9 @@ export function createTableState<DataItem = any>(params: CreateTableStateParams<
         index: resourceIndex,
         data: resource,
         columns: tableColumns.get().map(column => {
-          return {
-            ...column,
-            get title() {
-              return column.renderValue?.(row, column)
-            },
-          }
+          return Object.defineProperty(column, 'title', {
+            get: () => column.renderValue?.(row, column)
+          })
         }),
         get selected() {
           return selectedRowsId.has(row.id);


### PR DESCRIPTION
In this PR I fixed unnecessary recalculation of rows when a column size changes. This change improved performance of column resizing.

## Resizing performance before

https://github.com/ixrock/mobx-react-table-grid/assets/18424848/c304eec1-a1d6-4591-ad0f-ba35b5b05c78

## Resizing performance after

https://github.com/ixrock/mobx-react-table-grid/assets/18424848/577433ce-59c8-4a63-b98b-6522b47bf696

